### PR TITLE
Updated build.gradle. Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -10,6 +11,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
On some machines may occure error, when Android Studio just not see ".jar" libraries, because of old gradle version.
Here's the fix - added lines "google()" in [ buildscript -> repositories ] and [ allproject -> repositories ] in file "build.gradle".